### PR TITLE
replace jsonlite::fromJSON call with RcppSimdJson::fparse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     isoband,
     methods,
     googlePolylines,
-    sf
+    sf,
+    RcppSimdJson
 Depends:
     R (>= 3.5.0)
 Suggests: mapsf, lwgeom, tinytest, covr, sp

--- a/R/osrmTable.R
+++ b/R/osrmTable.R
@@ -148,8 +148,7 @@ osrmTable <- function(loc, src = NULL, dst = NULL, exclude = NULL,
         req_handle <- curl::new_handle(verbose = FALSE)
         curl::handle_setopt(req_handle, useragent = "osrm_R_package")
         resraw <- curl::curl_fetch_memory(utils::URLencode(req), handle = req_handle)
-        resjson <- jsonlite::prettify(rawToChar(resraw$content))
-        res <- jsonlite::fromJSON(resjson)
+        res <- RcppSimdJson::fparse(rawToChar(resraw$content))
         
       }, silent = TRUE)
       if (class(x)=="try-error") {


### PR DESCRIPTION
Hi,

Thanks for making this open source. I ran into an issue when trying to calculate a drive distance & time matrix of size 13989*2171. The OSRM call returns in 4 minutes, but the jsonlite::fromJSON function was taking more than double that. This PR replaces jsonlite::fromJSON with a more performant JSON parser.

Some indicative performance differences:

```
time python -c 'import json; json.load(open("result.json"))'

real    0m7.593s
user    0m6.092s
sys     0m1.061s

time R -q -e 'r=jsonlite::fromJSON("result.json")'
> r=jsonlite::fromJSON("result.json")
>
>

real    0m43.756s
user    0m33.069s
sys     0m3.968s

time R -q -e 'r=RcppSimdJson::fload("result.json")'
> r=RcppSimdJson::fload("result.json")
>
>

real    0m2.245s
user    0m1.624s
sys     0m0.314s
```