### PR TITLE
Allow submitting coords/data as a tibble

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -98,7 +98,14 @@ input_table <- function(x, id) {
         call. = FALSE
       )
     }
-    if (ncol(x) == 2 && is.numeric(x[, 1]) && is.numeric(x[, 2])) {
+    if (inherits(x = x, what = "matrix")) {
+      x_lon <- x[, 1]
+      x_lat <- x[, 2]
+    } else {
+      x_lon <- x[[colnames(x)[1]]]
+      x_lat <- x[[colnames(x)[1]]]
+    }
+    if (ncol(x) == 2 && is.numeric(x_lon) && is.numeric(x_lat)) {
       rn <- row.names(x)
       if (is.null(rn)) {
         rn <- 1:lx
@@ -106,8 +113,8 @@ input_table <- function(x, id) {
 
       x <- data.frame(
         id = rn,
-        lon = clean_coord(x[, 1]),
-        lat = clean_coord(x[, 2])
+        lon = clean_coord(x_lon),
+        lat = clean_coord(x_lat)
       )
       return(x)
     } else {
@@ -251,9 +258,16 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE) {
       if (lx < 2) {
         stop('"loc" should have at least 2 rows.', call. = FALSE)
       }
-      if (ncol(x) == 2 && is.numeric(x[, 1]) && is.numeric(x[, 2])) {
-        lon <- clean_coord(x[, 1])
-        lat <- clean_coord(x[, 2])
+      if (inherits(x = x, what = "matrix")) {
+        x_lon <- x[, 1]
+        x_lat <- x[, 2]
+      } else {
+        x_lon <- x[[colnames(x)[1]]]
+        x_lat <- x[[colnames(x)[1]]]
+      }
+      if (ncol(x) == 2 && is.numeric(x_lon) && is.numeric(x_lat)) {
+        lon <- clean_coord(x_lon)
+        lat <- clean_coord(x_lat)
         rn <- row.names(x)
         if (is.null(rn)) {
           rn <- 1:lx


### PR DESCRIPTION
This change will not change or break any existing behaviour but will work if the coordinates are submitted in a tibble.

I was trying to submit coordinates in a tibble and was getting an odd error which I traced to the utils script. Since tibble inherits from data.frame it was passing the first check but was then causing an error later since `x[,1]` on a tibble will return a single column tibble rather than the expected vector.

All the tests pass but I didn't add any new ones as I couldn't see a way to do that without at least adding a development dependency on `{tibble}`